### PR TITLE
Add support for TOML config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ or
 | -h, --help | Displays a help message |
 | -o, --output [location] | Specifies the location to save converted files, creates a new folder if location doesn't exist, defaults to textml/ |
 | -l, --lang [language-code] | Specifies a language for the <html lang=...> element in the <html> root element |
+| -c, --config [options-configuration] | Specifies all the options in a TOML formatted configuration file instead of having to pass them all as command line arguments every time. |
 
 ## Examples
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,5 @@
+output = "./build"
+lang = "fr"
+
+# Ignore unsupported options
+stylesheet = "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"

--- a/textml.py
+++ b/textml.py
@@ -3,8 +3,9 @@
 import os
 import argparse
 import shutil
-
 import convertUtils as utils
+import tomli
+import sys
 
 class Metadata:
     version = "v0.1.7"
@@ -14,7 +15,28 @@ def directory_setup(dir):
         shutil.rmtree(dir)  # Removing directory and its contents
 
     os.mkdir(dir)      # Creating directory
-       
+
+def read_config_file(original_args, file_path):
+    """Parses the toml configuration file, returns the parsed options as a dictionary"""
+
+    # Start with default arguments
+    args = original_args
+
+    # Read the TOML file
+    try:
+        with open(file_path, "rb") as file:
+                custom_configuration = tomli.load(file)
+    except tomli.TOMLDecodeError:
+        sys.exit("Supplied TOML file is not valid.")
+    except:
+        sys.exit("File path supplied to --config or -c option is invalid.")
+
+    # Set the specified options, use default if any not specified 
+    for (key, value) in custom_configuration.items():
+        setattr(args, key, value)
+
+    return args
+
 def main():
     outDir = "til/"              # Setting default output directory  
     lang = "en-CA"
@@ -26,8 +48,12 @@ def main():
     parser.add_argument('input', metavar='input', type=str, help="The provided .txt/.md file or a folder/directory of .txt/.md files to be converted")
     parser.add_argument('-o','--output', metavar='output', type=str, help="Optionally specifies a directory to save converted HTML files (Creates folder if one does not exist")
     parser.add_argument('-l','--lang', metavar='lang', type=str, help="Specifies a language for the <html lang=...> element in the <html> root element")
+    parser.add_argument('-c','--config', metavar='config', type=str, help="Allows to specify all the options in a TOML formatted configuration file instead of having to pass them all as command line arguments every time.")
 
     args = parser.parse_args()
+
+    if args.config is not None:
+        args = read_config_file(args, args.config)
 
     if args.output:
         outDir = args.output


### PR DESCRIPTION
I've finished adding support for `TOML` config files.

* You can specify a file path with `-c` or `--config` flag.
* If the path is invalid, the process exits with the error "File path supplied to --config or -c option is invalid."
* If the specified file is not a valid `TOML` file, the process exits with the error "Supplied TOML file is not valid."
* If the specified file is a valid `TOML` file, all the options on the command line are overridden.
* The program should ignore any options in the config file it doesn't recognize. For example, if the app doesn't support stylesheets, ignore a stylesheet property.
* If the config file is missing any options, the usual defaults are assumed

I'll finish working on the `README` soon and mark this PR for review.